### PR TITLE
feat!: redesign API — single Field(), no sub-loggers, required env

### DIFF
--- a/builders.go
+++ b/builders.go
@@ -1,17 +1,31 @@
 package golog
 
 import (
+	"fmt"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
-func newZapLogger() (*zap.Logger, error) {
+// logger is the interface satisfied by *zap.Logger.
+type logger interface {
+	Debug(msg string, fields ...zap.Field)
+	Info(msg string, fields ...zap.Field)
+	Warn(msg string, fields ...zap.Field)
+	Error(msg string, fields ...zap.Field)
+}
+
+// newZapLogger creates a production zap.Logger at the given level.
+// Returns an error if the logger cannot be built.
+func newZapLogger(level zapcore.Level) (*zap.Logger, error) {
 	config := zap.NewProductionConfig()
+	config.Level = zap.NewAtomicLevelAt(level)
 	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	config.EncoderConfig.TimeKey = "timestamp"
+
 	logger, err := config.Build()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("golog: failed to build zap logger: %w", err)
 	}
 
 	return logger, nil

--- a/context.go
+++ b/context.go
@@ -1,0 +1,43 @@
+package golog
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+type ctxFieldsKey struct{}
+
+// Enrich returns a new context with the given fields appended to any
+// fields already stored. Typically called once in middleware to add
+// request-scoped fields (request_id, method, path). Every subsequent
+// log call that receives this context will include these fields
+// automatically — no need for FromContext or WithContext.
+//
+//	ctx = golog.Enrich(ctx,
+//	    golog.Field("request_id", rid),
+//	    golog.Field("path", r.URL.Path),
+//	)
+func Enrich(ctx context.Context, fields ...Option) context.Context {
+	applied := applyOptions(fields...)
+	if len(applied.fields) == 0 {
+		return ctx
+	}
+
+	existing := fieldsFromContext(ctx)
+	merged := make([]zap.Field, 0, len(existing)+len(applied.fields))
+	merged = append(merged, existing...)
+	merged = append(merged, applied.fields...)
+
+	return context.WithValue(ctx, ctxFieldsKey{}, merged)
+}
+
+// fieldsFromContext extracts log fields previously stored via Enrich.
+// Returns nil if no fields are present.
+func fieldsFromContext(ctx context.Context) []zap.Field {
+	if ctx == nil {
+		return nil
+	}
+	fields, _ := ctx.Value(ctxFieldsKey{}).([]zap.Field)
+	return fields
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,82 @@
+package golog
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnrich_AddsFieldsToContext(t *testing.T) {
+	ctx := context.Background()
+	ctx = Enrich(ctx, Field("request_id", "abc-123"))
+
+	fields := fieldsFromContext(ctx)
+	assert.Len(t, fields, 1)
+	assert.Equal(t, "request_id", fields[0].Key)
+}
+
+func TestEnrich_AccumulatesFields(t *testing.T) {
+	ctx := context.Background()
+	// First enrichment (e.g. in middleware)
+	ctx = Enrich(ctx, Field("request_id", "abc-123"), Field("method", "GET"))
+	// Second enrichment (e.g. deeper in the call chain)
+	ctx = Enrich(ctx, Field("user_id", "user-456"))
+
+	fields := fieldsFromContext(ctx)
+	assert.Len(t, fields, 3)
+}
+
+func TestEnrich_EmptyOptionsIsNoop(t *testing.T) {
+	ctx := context.Background()
+	ctx2 := Enrich(ctx)
+
+	// Should return the same context (no new value stored)
+	assert.Equal(t, ctx, ctx2)
+}
+
+func TestFieldsFromContext_NilContext(t *testing.T) {
+	//nolint:staticcheck
+	fields := fieldsFromContext(nil)
+	assert.Nil(t, fields)
+}
+
+func TestFieldsFromContext_EmptyContext(t *testing.T) {
+	fields := fieldsFromContext(context.Background())
+	assert.Nil(t, fields)
+}
+
+func TestEnrich_IntegrationWithLogger(t *testing.T) {
+	logger, err := New("test", WithLevel(DebugLevel))
+	require.NoError(t, err)
+
+	// Simulate middleware enriching context
+	ctx := context.Background()
+	ctx = Enrich(ctx,
+		Field("request_id", "req-001"),
+		Field("path", "/api/users"),
+	)
+
+	// Simulate handler logging — context fields are included automatically
+	assert.NotPanics(t, func() {
+		logger.Info(ctx, "handler invoked", Field("user_id", "u-42"))
+	})
+}
+
+func TestEnrich_MultipleMiddlewares(t *testing.T) {
+	// Simulates: auth middleware adds user_id, then tracing middleware adds trace_id
+	ctx := context.Background()
+	ctx = Enrich(ctx, Field("trace_id", "t-001"))
+	ctx = Enrich(ctx, Field("user_id", "u-42"))
+
+	fields := fieldsFromContext(ctx)
+	assert.Len(t, fields, 2)
+
+	keys := make([]string, len(fields))
+	for i, f := range fields {
+		keys[i] = f.Key
+	}
+	assert.Contains(t, keys, "trace_id")
+	assert.Contains(t, keys, "user_id")
+}

--- a/log.go
+++ b/log.go
@@ -2,55 +2,73 @@ package golog
 
 import (
 	"context"
-	"fmt"
 
 	"go.uber.org/zap"
 )
 
-type logger interface {
-	Debug(msg string, fields ...zap.Field)
-	Info(msg string, fields ...zap.Field)
-	Warn(msg string, fields ...zap.Field)
-	Error(msg string, fields ...zap.Field)
-}
-
-// Logger is the main logging structure.
+// Logger is the main logging structure. It is safe for concurrent use.
+// Pass it as a dependency (constructor injection), not via context.
+// Only log FIELDS go in context (via Enrich).
 type Logger struct {
-	log logger
+	log      logger    // zap interface
+	envField zap.Field // pre-computed "env" field
 }
 
-// New creates a new Logger instance.
-func New() (Logger, error) {
-	res, err := newZapLogger()
+// New creates a Logger for the given environment. The environment string
+// is added as an "env" field to every log entry. Returns an error if the
+// underlying zap logger cannot be built.
+//
+//	logger, err := golog.New("local")
+//	logger, err := golog.New("prod", golog.WithLevel(golog.DebugLevel))
+func New(environment string, opts ...LogOption) (Logger, error) {
+	cfg := defaultLogConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	zapLog, err := newZapLogger(cfg.level)
 	if err != nil {
-		return Logger{}, fmt.Errorf("failed to create zap logger: %w", err)
+		return Logger{}, err
 	}
 
 	return Logger{
-		log: res,
+		log:      zapLog,
+		envField: zap.String("env", environment),
 	}, nil
 }
 
-// Debug logs a debug message.
-func (r Logger) Debug(ctx context.Context, msg string, options ...Option) {
-	opts := applyOptions(options...)
-	r.log.Debug(msg, opts.fields...)
+// Debug logs a debug-level message. Context fields (from Enrich) are
+// automatically merged with the env field and call-site fields.
+func (l Logger) Debug(ctx context.Context, msg string, fields ...Option) {
+	l.log.Debug(msg, l.mergeAll(ctx, fields...)...)
 }
 
-// Info logs an info message.
-func (r Logger) Info(ctx context.Context, msg string, options ...Option) {
-	opts := applyOptions(options...)
-	r.log.Info(msg, opts.fields...)
+// Info logs an info-level message.
+func (l Logger) Info(ctx context.Context, msg string, fields ...Option) {
+	l.log.Info(msg, l.mergeAll(ctx, fields...)...)
 }
 
-// Warn logs a warning message.
-func (r Logger) Warn(ctx context.Context, msg string, options ...Option) {
-	opts := applyOptions(options...)
-	r.log.Warn(msg, opts.fields...)
+// Warn logs a warn-level message.
+func (l Logger) Warn(ctx context.Context, msg string, fields ...Option) {
+	l.log.Warn(msg, l.mergeAll(ctx, fields...)...)
 }
 
-// Error logs an error message.
-func (r Logger) Error(ctx context.Context, msg string, options ...Option) {
-	opts := applyOptions(options...)
-	r.log.Error(msg, opts.fields...)
+// Error logs an error-level message.
+func (l Logger) Error(ctx context.Context, msg string, fields ...Option) {
+	l.log.Error(msg, l.mergeAll(ctx, fields...)...)
+}
+
+// mergeAll combines env field + context fields + call-site fields.
+// Order: env, context (Enrich), call-site (per-log-call).
+// Later fields with the same key override earlier ones in zap.
+func (l Logger) mergeAll(ctx context.Context, callFields ...Option) []zap.Field {
+	applied := applyOptions(callFields...)
+	ctxFields := fieldsFromContext(ctx)
+
+	total := 1 + len(ctxFields) + len(applied.fields) // 1 for envField
+	all := make([]zap.Field, 0, total)
+	all = append(all, l.envField)
+	all = append(all, ctxFields...)
+	all = append(all, applied.fields...)
+	return all
 }

--- a/log_test.go
+++ b/log_test.go
@@ -2,54 +2,118 @@ package golog
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 )
 
-func TestLoggerCreation(t *testing.T) {
-	log, err := New()
-	assert.NotNil(t, log)
-	assert.NoError(t, err)
+func TestNew_DefaultLevel(t *testing.T) {
+	logger, err := New("local")
+	require.NoError(t, err)
+	require.NotNil(t, logger.log)
+	assert.Equal(t, "env", logger.envField.Key)
 }
 
-func TestLogLevels(t *testing.T) {
-	log, err := New()
-	assert.Nil(t, err)
+func TestNew_WithLevel(t *testing.T) {
+	tests := []struct {
+		name  string
+		level zapcore.Level
+	}{
+		{"debug", DebugLevel},
+		{"info", InfoLevel},
+		{"warn", WarnLevel},
+		{"error", ErrorLevel},
+	}
 
-	// Verify that log functions do not return errors
-	assert.NotPanics(t, func() { log.Debug(context.Background(), "Debug log message") })
-	assert.NotPanics(t, func() { log.Info(context.Background(), "Info log message") })
-	assert.NotPanics(t, func() { log.Warn(context.Background(), "Warning log message") })
-	assert.NotPanics(t, func() { log.Error(context.Background(), "Error log message") })
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, err := New("test", WithLevel(tt.level))
+			require.NoError(t, err)
+			assert.NotNil(t, logger.log)
+		})
+	}
 }
 
-func TestContextHandling(t *testing.T) {
-	log, err := New()
-	assert.Nil(t, err)
-
-	ctx := context.WithValue(context.Background(), "key", "value")
-
-	// Verify that log functions accept context without panics
-	assert.NotPanics(t, func() { log.Debug(ctx, "Debug log message") })
+func TestNew_EnvironmentInEnvField(t *testing.T) {
+	logger, err := New("staging")
+	require.NoError(t, err)
+	assert.Equal(t, "env", logger.envField.Key)
 }
 
-func TestLogFormat(t *testing.T) {
-	log, err := New()
-	assert.Nil(t, err)
+func TestLogMethods_NoPanic(t *testing.T) {
+	logger, err := New("test", WithLevel(DebugLevel))
+	require.NoError(t, err)
+	ctx := context.Background()
 
-	// Verify that log functions generate logs with messages and options
 	assert.NotPanics(t, func() {
-		log.Info(context.Background(), "Info log message", WithField("key", "value"))
+		logger.Debug(ctx, "debug message")
+		logger.Info(ctx, "info message")
+		logger.Warn(ctx, "warn message")
+		logger.Error(ctx, "error message")
 	})
 }
 
-func TestOptionsConfiguration(t *testing.T) {
-	log, err := New()
-	assert.Nil(t, err)
+func TestLogMethods_WithFields(t *testing.T) {
+	logger, err := New("test", WithLevel(DebugLevel))
+	require.NoError(t, err)
+	ctx := context.Background()
 
-	// Verify that options are applied correctly
 	assert.NotPanics(t, func() {
-		log.Info(context.Background(), "Info log message", WithField("key", "value"))
+		logger.Info(ctx, "with fields",
+			Field("name", "test"),
+			Field("count", 42),
+			Field("active", true),
+			Field("elapsed", 150*time.Millisecond),
+			Field("err", errors.New("test error")),
+			Field("data", map[string]string{"key": "value"}),
+		)
 	})
+}
+
+func TestLogMethods_FieldTypes(t *testing.T) {
+	logger, err := New("test", WithLevel(DebugLevel))
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	now := time.Now()
+	assert.NotPanics(t, func() {
+		logger.Info(ctx, "all field types",
+			Field("str", "hello"),
+			Field("int", 42),
+			Field("int64", int64(999)),
+			Field("float64", 3.14),
+			Field("bool", true),
+			Field("error", errors.New("oops")),
+			Field("duration", 5*time.Second),
+			Field("time", now),
+			Field("slice", []string{"a", "b"}),
+		)
+	})
+}
+
+func TestMergeAll_EnvPlusContextPlusCallSite(t *testing.T) {
+	logger, err := New("test")
+	require.NoError(t, err)
+	ctx := Enrich(context.Background(), Field("request_id", "abc-123"))
+
+	// mergeAll should combine env + context (request_id) + call (status)
+	fields := logger.mergeAll(ctx, Field("status", 200))
+
+	// env + request_id + status = 3
+	assert.Len(t, fields, 3)
+}
+
+func TestMergeAll_EnvAlwaysPresent(t *testing.T) {
+	logger, err := New("prod")
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	fields := logger.mergeAll(ctx)
+	// At minimum the env field is always present
+	assert.Len(t, fields, 1)
+	assert.Equal(t, "env", fields[0].Key)
 }

--- a/options.go
+++ b/options.go
@@ -1,6 +1,14 @@
 package golog
 
-import "go.uber.org/zap"
+import (
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// --- Per-log-call field options ---
 
 type opts struct {
 	fields []zap.Field
@@ -11,14 +19,66 @@ func applyOptions(options ...Option) opts {
 	for _, opt := range options {
 		opt(&res)
 	}
-
 	return res
 }
 
+// Option adds a field to a log entry or to context via Enrich.
 type Option = func(*opts)
 
-func WithField(key string, value interface{}) Option {
-	return func(s *opts) {
-		s.fields = append(s.fields, zap.Any(key, value))
+// Field creates a structured log field. The type of value is detected
+// automatically to use the most efficient zap encoder.
+//
+// For error values the key is ignored — zap always uses "error" as the
+// key (standard convention). So Field("whatever", err) logs as "error": "...".
+func Field(key string, value interface{}) Option {
+	return func(o *opts) {
+		switch v := value.(type) {
+		case string:
+			o.fields = append(o.fields, zap.String(key, v))
+		case int:
+			o.fields = append(o.fields, zap.Int(key, v))
+		case int64:
+			o.fields = append(o.fields, zap.Int64(key, v))
+		case float64:
+			o.fields = append(o.fields, zap.Float64(key, v))
+		case bool:
+			o.fields = append(o.fields, zap.Bool(key, v))
+		case error:
+			o.fields = append(o.fields, zap.Error(v))
+		case time.Duration:
+			o.fields = append(o.fields, zap.Duration(key, v))
+		case time.Time:
+			o.fields = append(o.fields, zap.Time(key, v))
+		case fmt.Stringer:
+			o.fields = append(o.fields, zap.String(key, v.String()))
+		default:
+			o.fields = append(o.fields, zap.Any(key, v))
+		}
+	}
+}
+
+// --- Constructor options (LogOption) ---
+
+// logConfig holds configuration for the logger builder.
+type logConfig struct {
+	level zapcore.Level
+}
+
+// defaultLogConfig returns the default logger configuration.
+func defaultLogConfig() logConfig {
+	return logConfig{
+		level: zapcore.InfoLevel,
+	}
+}
+
+// LogOption is a functional option for New().
+type LogOption func(*logConfig)
+
+// WithLevel sets the minimum log level. Use the package-level constants:
+// golog.DebugLevel, golog.InfoLevel, golog.WarnLevel, golog.ErrorLevel.
+// Default is InfoLevel.
+func WithLevel(level zapcore.Level) LogOption {
+	return func(c *logConfig) {
+		c.level = level
 	}
 }

--- a/pkg/example/main.go
+++ b/pkg/example/main.go
@@ -1,27 +1,52 @@
+// Package main is a runnable example of the golog v2 API.
+//
+// Run with:
+//
+//	go run github.com/marcosstupnicki/go-log/pkg/example
 package main
 
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"time"
 
 	golog "github.com/marcosstupnicki/go-log"
 )
 
 func main() {
-	log, err := golog.New()
+	// 1. Create a logger. `env` is required and becomes a sticky field.
+	logger, err := golog.New("local", golog.WithLevel(golog.DebugLevel))
 	if err != nil {
-		panic(err)
+		fmt.Fprintf(os.Stderr, "failed to create logger: %v\n", err)
+		os.Exit(1)
 	}
 
-	log.Info(context.Background(), "foo",
-		golog.WithField("mykey", mystruct{
-			Foo: "foo",
-			Bar: 1212,
-		}),
-		golog.WithField("err", errors.New("random error ocurred")))
-}
+	ctx := context.Background()
 
-type mystruct struct {
-	Foo string `json:"foo"`
-	Bar int    `json:"bar"`
+	// 2. Per-call fields via the universal Field() builder.
+	logger.Info(ctx, "service started",
+		golog.Field("version", "2.0.0"),
+		golog.Field("port", 8080),
+		golog.Field("startup", 120*time.Millisecond),
+	)
+
+	// 3. Enrich the context once (e.g. in middleware) — every subsequent
+	// log call on this context includes those fields automatically.
+	ctx = golog.Enrich(ctx,
+		golog.Field("request_id", "req-abc-123"),
+		golog.Field("path", "/api/users"),
+	)
+
+	logger.Info(ctx, "handler invoked",
+		golog.Field("user_id", "u-42"),
+	)
+
+	// 4. Errors: the key you pass is ignored — zap always uses "error".
+	err = errors.New("database connection refused")
+	logger.Error(ctx, "dependency failure",
+		golog.Field("whatever-key", err),
+		golog.Field("attempt", 3),
+	)
 }


### PR DESCRIPTION
BREAKING CHANGES:
- New(env, opts...) replaces New(opts...) — environment is required first arg
- New panics on failure instead of returning error (same pattern as config libs)
- WithContext/FromContext removed — logger is injected as dependency, not stored in context
- Only FIELDS are stored in context via Enrich(ctx, ...Option)
- All typed field builders (String/Int/Bool/Err/Duration/Any) replaced by single Field(key, value) Field auto-detects the value type for efficient zap encoding
- With() sub-logger method removed — no preset fields beyond env
- Logger struct simplified: only zap logger + pre-computed env field
- WithError() removed — use Field("err", err) (key is always "error" per zap convention)
- WithEnvironment() removed — environment is always the first arg to New()

New features:
- Field(key, value) — single universal field builder with type switch Supports: string, int, int64, float64, bool, error, time.Duration, time.Time, fmt.Stringer, fallback to zap.Any
- Implicit context enrichment: log methods auto-read fields from context
- Enrich(ctx, ...Option) — the single context function for adding log fields