### PR TITLE
Expose public log level parsing API

### DIFF
--- a/level.go
+++ b/level.go
@@ -1,12 +1,46 @@
 package golog
 
 import (
+	"fmt"
+	"strings"
+
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
+// Level is go-log's public log level type. It aliases zapcore.Level because
+// go-log intentionally wraps zap while keeping call sites out of zapcore.
+type Level = zapcore.Level
+
 const (
-	DebugLevel = zap.DebugLevel
-	InfoLevel  = zap.InfoLevel
-	WarnLevel  = zap.WarnLevel
-	ErrorLevel = zap.ErrorLevel
+	DebugLevel Level = zap.DebugLevel
+	InfoLevel  Level = zap.InfoLevel
+	WarnLevel  Level = zap.WarnLevel
+	ErrorLevel Level = zap.ErrorLevel
 )
+
+// ParseLevel parses common textual log levels accepted by go-log.
+func ParseLevel(v string) (Level, error) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "debug":
+		return DebugLevel, nil
+	case "info":
+		return InfoLevel, nil
+	case "warn", "warning":
+		return WarnLevel, nil
+	case "error":
+		return ErrorLevel, nil
+	default:
+		return InfoLevel, fmt.Errorf("golog: invalid log level %q (valid: debug, info, warn, error)", v)
+	}
+}
+
+// MustParseLevel parses v and panics if it is invalid. It is useful in config
+// loaders that already panic on invalid environment values.
+func MustParseLevel(v string) Level {
+	level, err := ParseLevel(v)
+	if err != nil {
+		panic(err)
+	}
+	return level
+}

--- a/level_test.go
+++ b/level_test.go
@@ -1,0 +1,41 @@
+package golog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLevel(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want Level
+	}{
+		{name: "debug", in: "debug", want: DebugLevel},
+		{name: "info", in: "info", want: InfoLevel},
+		{name: "warn", in: "warn", want: WarnLevel},
+		{name: "warning alias", in: "warning", want: WarnLevel},
+		{name: "error", in: "error", want: ErrorLevel},
+		{name: "trim and case", in: " WARN ", want: WarnLevel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseLevel(tt.in)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseLevelRejectsUnknownLevel(t *testing.T) {
+	_, err := ParseLevel("verbose")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "debug, info, warn, error")
+}
+
+func TestMustParseLevelPanicsOnUnknownLevel(t *testing.T) {
+	assert.Panics(t, func() { _ = MustParseLevel("verbose") })
+}

--- a/log_test.go
+++ b/log_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 )
 
 func TestNew_DefaultLevel(t *testing.T) {
@@ -21,7 +20,7 @@ func TestNew_DefaultLevel(t *testing.T) {
 func TestNew_WithLevel(t *testing.T) {
 	tests := []struct {
 		name  string
-		level zapcore.Level
+		level Level
 	}{
 		{"debug", DebugLevel},
 		{"info", InfoLevel},

--- a/options.go
+++ b/options.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 // --- Per-log-call field options ---
@@ -61,13 +60,13 @@ func Field(key string, value interface{}) Option {
 
 // logConfig holds configuration for the logger builder.
 type logConfig struct {
-	level zapcore.Level
+	level Level
 }
 
 // defaultLogConfig returns the default logger configuration.
 func defaultLogConfig() logConfig {
 	return logConfig{
-		level: zapcore.InfoLevel,
+		level: InfoLevel,
 	}
 }
 
@@ -77,7 +76,7 @@ type LogOption func(*logConfig)
 // WithLevel sets the minimum log level. Use the package-level constants:
 // golog.DebugLevel, golog.InfoLevel, golog.WarnLevel, golog.ErrorLevel.
 // Default is InfoLevel.
-func WithLevel(level zapcore.Level) LogOption {
+func WithLevel(level Level) LogOption {
 	return func(c *logConfig) {
 		c.level = level
 	}


### PR DESCRIPTION
## Summary\n- Expose golog.Level as the public level type so callers don't need zapcore in config structs.\n- Add ParseLevel and MustParseLevel helpers for env/config parsing.\n- Keep WithLevel on the public golog.Level type while preserving zapcore internally.\n\n## Tests\n- go test ./...